### PR TITLE
Improved handling of fields of type `time.Time` in the validation process

### DIFF
--- a/structcheck.go
+++ b/structcheck.go
@@ -105,6 +105,10 @@ func (g *Validate) checkList(v reflect.Value, tree string) error {
 func (g *Validate) checkStruct(v reflect.Value, tree string) error {
 	t := v.Type()
 	for i := 0; i < t.NumField(); i++ {
+		if isTime(v.Field(i)) {
+			// lets ignore time.Time fields, they are already checked in bindJSON
+			continue
+		}
 		err := g.checkField(v, t, tree, i)
 		if err != nil {
 			return err


### PR DESCRIPTION
### Release Notes - Godantic v1.0.4

#### Highlights:
- Improved handling of fields of type `time.Time` in the validation process.

#### Changes:
1. **Validation Update**: 
   - Previously, `godantic` attempted to validate fields of type `time.Time`, which resulted in unexpected behavior. We've identified that time fields might be validated elsewhere in the user's code or might not need the same generic checks as other fields.
   - With this release, `godantic` will skip the validation for fields of type `time.Time` within the `checkStruct` function. This means fields of type `time.Time` will no longer be subject to the default validation logic. However, users can still apply custom validation to `time.Time` fields outside of `godantic`.

#### Bug Fixes:
- Resolved the panic error caused by attempting to validate unexported fields of type `time.Time`.
  
#### How to Upgrade:
- To incorporate these changes and improvements, please upgrade to `godantic` version `1.0.4`.

---

You can adjust the above release note as per the other changes or nuances in your package that might be relevant to your users. It's always a good idea to be thorough and clear in release notes to make it easier for users to understand changes and decide when and how to upgrade.