### PR TITLE
feature: validate custom regular expression and standard formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Godantic
 
-Godantic is a Go package for inspecting and validating JSON-like data against Go struct types and schemas. It provides functionalities for checking type compatibility, structure compatibility, and other validations such as empty string, invalid time, and minimum length list checks.
+Godantic is a Go package for inspecting and validating JSON-like data against Go struct types and schemas. It provides functionalities for checking type compatibility, structure compatibility, and other validations such as empty string, invalid time, minimum length list checks, regex pattern matching, and format validation.
 
 ## Getting Started
 
@@ -20,8 +20,8 @@ import "github.com/grahms/godantic"
 
 ```go
 type Person struct {
-	Name *string `json:"name" binding:"required"`
-	Age  *int    `json:"age"`
+    Name *string `json:"name" binding:"required"`
+    Age  *int    `json:"age"`
 }
 
 var jsonData = []byte(`{"name": "John", "age": 30}`)
@@ -41,8 +41,8 @@ if err != nil {
 
 ```go
 type Person struct {
-	Name *string `json:"name" binding:"required"`
-	Role *string `json:"role" enum:"admin,user"`
+    Name *string `json:"name" binding:"required"`
+    Role *string `json:"role" enum:"admin,user"`
 }
 
 // Here, the Role field must be either 'admin' or 'user'. If it's not, an error is returned.
@@ -66,15 +66,15 @@ if err != nil {
 
 ```go
 type CustomError struct {
-	ErrType string
-	Message string
-	Path    string
-	err     error
+    ErrType string
+    Message string
+    Path    string
+    err     error
 }
 
 func (e *CustomError) Error() string {
-	e.err = errors.New(e.Message)
-	return e.err.Error()
+    e.err = errors.New(e.Message)
+    return e.err.Error()
 }
 
 // Now you can create your own error type and return it in your custom validation functions.
@@ -94,23 +94,23 @@ if err != nil {
 
 ```go
 type Address struct {
-	City  *string `json:"city" binding:"required"`
-	State *string `json:"state" binding:"required"`
+    City  *string `json:"city" binding:"required"`
+    State *string `json:"state" binding:"required"`
 }
 
 type Person struct {
-	Name    *string `json:"name" binding:"required"`
-	Age     *int    `json:"age"`
-	Address *Address `json:"address"`
+    Name    *string `json:"name" binding:"required"`
+    Age     *int    `json:"age"`
+    Address *Address `json:"address"`
 }
 
 var jsonData = []byte(`{
-	"name": "John",
-	"age": 30,
-	"address": {
-		"city": "New York",
-		"state": "NY"
-	}
+    "name": "John",
+    "age": 30,
+    "address": {
+        "city": "New York",
+        "state": "NY"
+    }
 }`)
 
 var person Person
@@ -129,29 +129,29 @@ In this example, the `Person` struct has a nested `Address` struct. The `godanti
 
 ```go
 type Skill struct {
-	Name *string `json:"name" binding:"required"`
-	Level *int `json:"level"`
+    Name *string `json:"name" binding:"required"`
+    Level *int `json:"level"`
 }
 
 type Person struct {
-	Name  *string `json:"name" binding:"required"`
-	Age   *int    `json:"age"`
-	Skills []Skill `json:"skills"`
+    Name  *string `json:"name" binding:"required"`
+    Age   *int    `json:"age"`
+    Skills []Skill `json:"skills"`
 }
 
 var jsonData = []byte(`{
-	"name": "John",
-	"age": 30,
-	"skills": [
-		{
-			"name": "Go",
-			"level": 5
-		},
-		{
-			"name": "Python",
-			"level": 4
-		}
-	]
+    "name": "John",
+    "age": 30,
+    "skills": [
+        {
+            "name": "Go",
+            "level": 5
+        },
+        {
+            "name": "Python",
+            "level": 4
+        }
+    ]
 }`)
 
 var person Person
@@ -166,7 +166,6 @@ if err != nil {
 
 In this example, the `Person` struct has a `Skills` field that is a slice of `Skill` structs. The `godantic` package will iterate over the list and validate each object in the list.
 
-
 ## Integration with Web Frameworks
 
 ### Using Godantic with Gin
@@ -177,40 +176,42 @@ Here's an example of how to use the `godantic` package with the Gin web framewor
 package main
 
 import (
-	"github.com/gin-gonic/gin"
-	"github.com/grahms/godantic"
-	"net/http"
+    "github.com/gin-gonic/gin"
+    "github.com/grahms/godantic"
+    "net/http"
 )
 
 type User struct {
-	Name    *string `json:"name" binding:"required"`
-	Email   *string `json:"email" binding:"required"`
-	Age     *int    `json:"age"`
+    Name    *string `json:"name" binding:"required"`
+    Email   *string `json:"email" binding:"required"`
+    Age     *int    `json:"age"`
 }
 
 func main() {
-	r := gin.Default()
+    r := gin.Default()
 
-	r.POST("/user", func(c *gin.Context) {
-		var user User
-		validator := godantic.Validate{}
+    r.POST("/user", func(c *gin.Context) {
+        var user User
+        validator := godantic.Validate{}
 
-		jsonData, err := c.GetRawData()
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-			return
-		}
+        jsonData, err := c.GetRawData()
+        if err != nil {
+            c.JSON(http
 
-		err = validator.BindJSON(jsonData, &user)
-		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-			return
-		}
+.StatusBadRequest, gin.H{"error": err.Error()})
+            return
+        }
 
-		c.JSON(http.StatusOK, gin.H{"status": "ok"})
-	})
+        err = validator.BindJSON(jsonData, &user)
+        if err != nil {
+            c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+            return
+        }
 
-	r.Run()
+        c.JSON(http.StatusOK, gin.H{"status": "ok"})
+    })
+
+    r.Run()
 }
 ```
 
@@ -244,6 +245,93 @@ Please remember that the Go's `json.Unmarshal` function used by `godantic` doesn
 - `INVALID_TIME_ERR`: Triggered when a time.Time field has an invalid time value.
 - `EMPTY_STRING_ERR`: Triggered when a string field is empty.
 - `EMPTY_LIST_ERR`: Triggered when a list field is empty.
+- `INVALID_REGEX_ERR`: Triggered when a field value does not match the required regex pattern.
+- `INVALID_FORMAT_ERR`: Triggered when a field value does not match the required format.
+
+## Format Tags
+
+The following table lists the supported format tags and their corresponding regular expressions:
+
+| Format Tag          | Description                      | Example Use Case                      |
+|---------------------|----------------------------------|---------------------------------------|
+| email               | Email address format             | Validating user email addresses       |
+| url                 | URL format                       | Validating website URLs               |
+| date                | Date format (YYYY-MM-DD)        | Validating dates in a specific format |
+| time                | Time format (HH:MM:SS)          | Validating times in a specific format |
+| uuid                | UUID format                      | Validating UUIDs                      |
+| ip                  | IP address format                | Validating IPv4 or IPv6 addresses     |
+| credit_card         | Credit card number format        | Validating credit card numbers        |
+| postal_code         | Postal code format               | Validating postal codes               |
+| phone               | Phone number format              | Validating phone numbers              |
+| ssn                 | Social Security Number format    | Validating SSN                        |
+| credit_card_expiry  | Credit card expiry date format  | Validating credit card expiry dates   |
+| latitude            | Latitude format                  | Validating latitude coordinates       |
+| longitude           | Longitude format                 | Validating longitude coordinates      |
+| hex_color           | Hex color format                 | Validating hex color codes            |
+| mac_address         | MAC address format               | Validating MAC addresses              |
+| html_tag            | HTML tag format                  | Validating HTML tags                  |
+| mz-msisdn           | Mozambican phone number format   | Validating Mozambican phone numbers   |
+| mz-nuit             | Mozambican NUIT format           | Validating Mozambican NUIT numbers    |
+
+
+
+## Using the `ignore` Tag
+
+The `ignore` tag allows you to exclude specific fields from input validation while still retaining them in the struct. This can be useful for fields representing metadata or internal information that shouldn't be validated during input but are required for other purposes.
+
+### Example
+
+Consider a `User` struct with an `ID` field that should be excluded from input validation but retained in the struct for internal use:
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/grahms/godantic"
+)
+
+type User struct {
+    ID        int    `json:"id" binding:"ignore"` // ID field is ignored during input validation
+    FirstName string `json:"first_name" binding:"required"`
+    LastName  string `json:"last_name" binding:"required"`
+    Email     string `json:"email" binding:"required" format:"email"`
+    // Other fields...
+}
+
+func main() {
+    // Example JSON data representing user input
+    jsonData := []byte(`{
+        "first_name": "John",
+        "last_name": "Doe",
+        "email": "john.doe@example.com"
+        // No "id" field included
+    }`)
+
+    // Create a new instance of the validator
+    validator := godantic.Validate{}
+
+    // Create an instance of the User struct
+    var user User
+
+    // Bind and validate the JSON data against the User struct
+    err := validator.BindJSON(jsonData, &user)
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+
+    // Validation successful, process the user data
+    fmt.Printf("User ID: %d\n", user.ID) // ID is still accessible despite being ignored during validation
+    fmt.Printf("Name: %s %s\n", user.FirstName, user.LastName)
+    fmt.Printf("Email: %s\n", user.Email)
+}
+```
+
+In this example:
+
+- The `ID` field represents a unique identifier for the user and is marked with the `ignore` tag.
+- Despite being ignored during validation, the `ID` field remains accessible in the `User` struct after validation, allowing you to utilize it for internal operations or data processing.
 
 ## Contributing
 
@@ -252,3 +340,6 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 ## License
 
 This project is licensed under the MIT License.
+
+
+This README.md includes detailed information about how to use Godantic, including simple and advanced usage examples, integration with web frameworks, features, error types, supported format tags, and more. If you have any further updates or modifications, please let me know!

--- a/struct_check_test.go
+++ b/struct_check_test.go
@@ -2,6 +2,7 @@ package godantic
 
 import (
 	"github.com/stretchr/testify/assert"
+	"regexp"
 	"testing"
 )
 
@@ -176,4 +177,259 @@ func TestStuckCheck(t *testing.T) {
 		assert.Equal(t, "address.city", err1.(*Error).Path)
 
 	})
+}
+func TestAlphanumericValidation(t *testing.T) {
+	g := &Validate{}
+
+	// Define a struct with a field requiring validation for alphanumeric characters
+	type testStruct struct {
+		MyField *string `json:"my_field" binding:"required" regex:"^[A-Za-z0-9]([A-Za-z0-9_-]*[A-Za-z0-9])?$"`
+	}
+
+	// Test case: MyField contains only alphanumeric characters
+	validValue := "abc123"
+	val1 := testStruct{MyField: &validValue}
+	err1 := g.InspectStruct(val1)
+	assert.NoError(t, err1)
+
+	// Test case: MyField contains non-alphanumeric characters
+	invalidValue := "abc$123"
+	val2 := testStruct{MyField: &invalidValue}
+	err2 := g.InspectStruct(val2)
+	assert.Error(t, err2)
+	assert.Equal(t, "INVALID_PATTERN_ERR", err2.(*Error).ErrType)
+	assert.Equal(t, "my_field", err2.(*Error).Path)
+}
+
+func TestRegexValidation(t *testing.T) {
+	g := &Validate{}
+
+	// Define a struct for email validation
+	type EmailStruct struct {
+		Email *string `json:"email" binding:"required" regex:"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"`
+	}
+
+	t.Run("Valid email format", func(t *testing.T) {
+		validEmail := "test@example.com"
+		val1 := EmailStruct{Email: &validEmail}
+		err1 := g.InspectStruct(val1)
+		assert.NoError(t, err1)
+	})
+
+	t.Run("Invalid email format", func(t *testing.T) {
+		invalidEmail := "invalid-email"
+		val2 := EmailStruct{Email: &invalidEmail}
+		err2 := g.InspectStruct(val2)
+		assert.Error(t, err2)
+	})
+
+	// Define a struct for phone number validation
+	type PhoneStruct struct {
+		Phone *string `json:"phone" binding:"required" regex:"^\\+[1-9]\\d{1,14}$"`
+	}
+
+	t.Run("Valid phone number format", func(t *testing.T) {
+		validPhone := "+1234567890"
+		val3 := PhoneStruct{Phone: &validPhone}
+		err3 := g.InspectStruct(val3)
+		assert.NoError(t, err3)
+	})
+
+	t.Run("Invalid phone number format", func(t *testing.T) {
+		invalidPhone := "1234567890"
+		val4 := PhoneStruct{Phone: &invalidPhone}
+		err4 := g.InspectStruct(val4)
+		assert.Error(t, err4)
+	})
+
+	// Define a struct for string length validation
+	type LengthStruct struct {
+		Length *string `json:"length" binding:"required" regex:"^.{8,12}$"`
+	}
+
+	t.Run("Valid length", func(t *testing.T) {
+		validLength := "abcdefgh"
+		val5 := LengthStruct{Length: &validLength}
+		err5 := g.InspectStruct(val5)
+		assert.NoError(t, err5)
+	})
+
+	t.Run("Invalid length", func(t *testing.T) {
+		invalidLength := "abc"
+		val6 := LengthStruct{Length: &invalidLength}
+		err6 := g.InspectStruct(val6)
+		assert.Error(t, err6)
+	})
+
+	// Define a struct for numerical range validation
+	type RangeStruct struct {
+		Range *string `json:"range" binding:"required" regex:"^([1-9]|[1-5][0-9]|6[0-4])$"`
+	}
+
+	t.Run("Valid range", func(t *testing.T) {
+		validRange := "50"
+		val7 := RangeStruct{Range: &validRange}
+		err7 := g.InspectStruct(val7)
+		assert.NoError(t, err7)
+	})
+
+	t.Run("Invalid range", func(t *testing.T) {
+		invalidRange := "70"
+		val8 := RangeStruct{Range: &invalidRange}
+		err8 := g.InspectStruct(val8)
+		assert.Error(t, err8)
+	})
+
+	// Define a struct for URL validation
+	type URLStruct struct {
+		URL *string `json:"url" binding:"required" regex:"^(http|https)://[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}(?:/[^\\s]*)?$"`
+	}
+
+	t.Run("Valid URL format", func(t *testing.T) {
+		validURL := "https://example.com"
+		val9 := URLStruct{URL: &validURL}
+		err9 := g.InspectStruct(val9)
+		assert.NoError(t, err9)
+	})
+
+	t.Run("Invalid URL format", func(t *testing.T) {
+		invalidURL := "invalid-url"
+		val10 := URLStruct{URL: &invalidURL}
+		err10 := g.InspectStruct(val10)
+		assert.Error(t, err10)
+	})
+
+	// Define a struct for date validation
+	type DateStruct struct {
+		Date *string `json:"date" binding:"required" regex:"^\\d{4}-\\d{2}-\\d{2}$"`
+	}
+
+	t.Run("Valid date format", func(t *testing.T) {
+		validDate := "2024-02-29"
+		val11 := DateStruct{Date: &validDate}
+		err11 := g.InspectStruct(val11)
+		assert.NoError(t, err11)
+	})
+
+	t.Run("Invalid date format", func(t *testing.T) {
+		invalidDate := "invalid-date"
+		val12 := DateStruct{Date: &invalidDate}
+		err12 := g.InspectStruct(val12)
+		assert.Error(t, err12)
+	})
+
+	// Define a struct for custom pattern validation
+	type CustomStruct struct {
+		Custom *string `json:"custom" binding:"required" regex:"^\\d{3}-\\d{2}-\\d{4}$"`
+	}
+
+	t.Run("Valid custom format", func(t *testing.T) {
+		validCustom := "123-45-6789"
+		val13 := CustomStruct{Custom: &validCustom}
+		err13 := g.InspectStruct(val13)
+		assert.NoError(t, err13)
+	})
+
+	t.Run("Invalid custom format", func(t *testing.T) {
+		invalidCustom := "invalid-custom"
+		val14 := CustomStruct{Custom: &invalidCustom}
+		err14 := g.InspectStruct(val14)
+		assert.Error(t, err14)
+	})
+
+}
+
+func TestFormatValidation(t *testing.T) {
+	g := &Validate{}
+
+	// Define a struct for email validation
+	type EmailStruct struct {
+		Email *string `json:"email" binding:"required" format:"email"`
+	}
+
+	t.Run("Valid email format", func(t *testing.T) {
+		validEmail := "test@example.com"
+		val1 := EmailStruct{Email: &validEmail}
+		err1 := g.InspectStruct(val1)
+		assert.NoError(t, err1)
+	})
+
+	t.Run("Invalid email format", func(t *testing.T) {
+		invalidEmail := "invalid-email"
+		val2 := EmailStruct{Email: &invalidEmail}
+		err2 := g.InspectStruct(val2)
+		assert.Error(t, err2)
+	})
+
+	// Define a struct for URL validation
+	type URLStruct struct {
+		URL *string `json:"url" binding:"required" format:"url"`
+	}
+
+	t.Run("Valid URL format", func(t *testing.T) {
+		validURL := "https://example.com"
+		val3 := URLStruct{URL: &validURL}
+		err3 := g.InspectStruct(val3)
+		assert.NoError(t, err3)
+	})
+
+	t.Run("Invalid URL format", func(t *testing.T) {
+		invalidURL := "invalid-url"
+		val4 := URLStruct{URL: &invalidURL}
+		err4 := g.InspectStruct(val4)
+		assert.Error(t, err4)
+	})
+}
+
+func TestGetFormatRegex(t *testing.T) {
+	testCases := []struct {
+		formatTag string
+		input     string
+		expected  bool
+	}{
+		{"email", "test@example.com", true},
+		{"email", "invalid-email", false},
+		{"url", "http://example.com", true},
+		{"url", "invalid-url", false},
+		{"date", "2024-02-29", true},
+		{"date", "invalid-date", false},
+		{"time", "12:34:56", true},
+		{"time", "25:00:00", false},
+		{"uuid", "123e4567-e89b-12d3-a456-426614174000", true},
+		{"uuid", "invalid-uuid", false},
+		{"ip", "192.168.1.1", true},
+		{"ip", "invalid-ip", false},
+		{"credit_card", "1234-5678-9012-3456", true},
+		{"credit_card", "invalid-credit-card", false},
+		{"postal_code", "12345", true},
+		{"postal_code", "invalid-postal-code", false},
+		{"phone", "+1234567890", true},
+		{"phone", "1234567890", false},
+		{"ssn", "123-45-6789", true},
+		{"ssn", "invalid-ssn", false},
+		{"credit_card_expiry", "02/2024", true},
+		{"credit_card_expiry", "invalid-expiry-date", false},
+		{"latitude", "45.678", true},
+		{"latitude", "invalid-latitude", false},
+		{"longitude", "-123.456", true},
+		{"longitude", "invalid-longitude", false},
+		{"hex_color", "#FFFFFF", true},
+		{"hex_color", "invalid-hex-color", false},
+		{"mac_address", "00:0a:95:9d:68:16", true},
+		{"mac_address", "invalid-mac-address", false},
+		{"mz-msisdn", "258123456789", true},
+		{"mz-msisdn", "123456789", false},
+		{"mz-nuit", "123456789", true},
+		{"mz-nuit", "invalid-nuit", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.formatTag, func(t *testing.T) {
+			regexPattern := getFormatRegex(tc.formatTag)
+			match := regexPattern != "" && regexp.MustCompile(regexPattern).MatchString(tc.input)
+			if match != tc.expected {
+				t.Errorf("For format tag %s and input %s, expected match: %v, got: %v", tc.formatTag, tc.input, tc.expected, match)
+			}
+		})
+	}
 }


### PR DESCRIPTION

## Format Tags
Godantic supports the following format tags for format validation:
- email
- url
- date
- time
- uuid
- ip
- credit_card
- postal_code
- phone
- ssn
- credit_card_expiry
- latitude
- longitude
- hex_color
- mac_address
- html_tag
- mz-msisdn
- mz-nuit

## `ignore` Tag
Introduced the `ignore` tag to allow exclusion of specific fields from input validation while retaining them in the struct. This is useful for fields representing metadata or internal information that shouldn't be validated during input but are required for other purposes.

## Error Types
Various error types are provided for different validation scenarios, including:
- INVALID_REGEX_ERR
- INVALID_FORMAT_ERR

## Examples and Usage
Updated the README.md file with detailed examples, usage instructions, integration with web frameworks, and more.
