### PR TITLE
feat: range validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,9 +333,93 @@ In this example:
 - The `ID` field represents a unique identifier for the user and is marked with the `ignore` tag.
 - Despite being ignored during validation, the `ID` field remains accessible in the `User` struct after validation, allowing you to utilize it for internal operations or data processing.
 
-Great! Now that **enum validation with conditions is working**, let's **update the README** to document this feature clearly.
 
 ---
+
+## 📐 Numeric & Decimal Constraints
+
+`godantic` supports advanced validation for numeric and decimal fields using struct tags. These rules enable expressive, type-safe constraints on your data models.
+
+### 🔢 `min` and `max` (generic)
+
+Used to validate:
+- String length
+- Slice/array length
+- Numeric values
+
+```go
+type User struct {
+  Name  *string `json:"name" min:"3" max:"50"`       // between 3 and 50 characters
+  Tags  *[]int  `json:"tags" min:"1" max:"5"`         // between 1 and 5 items
+  Age   *int    `json:"age" min:"18" max:"60"`        // between 18 and 60 years
+}
+```
+
+---
+
+### ⚖️ `gt`, `ge`, `lt`, `le` (value bounds)
+
+Used to enforce strict or inclusive numeric constraints.
+
+| Tag  | Meaning                        |
+|------|--------------------------------|
+| `gt` | value must be **greater than** |
+| `ge` | value must be **≥**            |
+| `lt` | value must be **less than**    |
+| `le` | value must be **≤**            |
+
+```go
+type Product struct {
+  Price *float64 `json:"price" gt:"0"`     // must be greater than 0
+  Stock *int     `json:"stock" le:"1000"`  // must be ≤ 1000
+}
+```
+
+---
+
+### 🎯 `multiple_of`
+
+Ensures the value is a multiple of a specified number.
+
+```go
+type Payment struct {
+  Amount *float64 `json:"amount" multiple_of:"0.05"` // e.g. currency in increments of 0.05
+}
+```
+
+---
+
+### 🧮 `max_digits` & `decimal_places`
+
+Validates decimal precision:
+
+| Tag              | Description                                                       |
+|------------------|-------------------------------------------------------------------|
+| `max_digits`     | Max total digits (excluding leading zero, includes decimals)      |
+| `decimal_places` | Max number of digits after the decimal point                      |
+
+```go
+type Invoice struct {
+  Total *float64 `json:"total" max_digits:"6" decimal_places:"2"` // e.g. 9999.99
+}
+```
+
+---
+
+### ☢️ `allow_inf_nan`
+
+Allows `+Inf`, `-Inf`, and `NaN` values for floating point numbers.
+
+```go
+type Reading struct {
+  Value *float64 `json:"value" allow_inf_nan:"true"`
+}
+```
+
+> 🔒 By default, `inf` and `NaN` are **not allowed**.
+
+---
+
 
 
 ## Conditional Validation Based on Enum Values

--- a/decimal_constraints.go
+++ b/decimal_constraints.go
@@ -1,0 +1,65 @@
+package godantic
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+func (g *Validate) checkDecimalConstraints(f reflect.StructField, v reflect.Value, tree string) error {
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+
+	if !(v.Kind() == reflect.Float32 || v.Kind() == reflect.Float64) {
+		return nil
+	}
+
+	value := v.Float()
+
+	str := strconv.FormatFloat(value, 'f', -1, 64) // string sem notação científica
+	str = strings.TrimRight(str, "0")              // remove zeros à direita
+	str = strings.TrimSuffix(str, ".")             // remove ponto solto
+
+	parts := strings.Split(str, ".")
+	intPart := parts[0]
+	decPart := ""
+	if len(parts) > 1 {
+		decPart = parts[1]
+	}
+
+	// Tags
+	maxDigitsTag := f.Tag.Get("max_digits")
+	decimalPlacesTag := f.Tag.Get("decimal_places")
+
+	if maxDigitsTag != "" {
+		if maxDigits, err := strconv.Atoi(maxDigitsTag); err == nil {
+			totalDigits := len(strings.TrimLeft(intPart, "-")) + len(decPart)
+			if totalDigits > maxDigits {
+				return &Error{
+					ErrType: "MAX_DIGITS_ERR",
+					Path:    fieldName(f, tree),
+					Message: fmt.Sprintf("The field <%s> must have at most %d total digits (got %d)", fieldName(f, tree), maxDigits, totalDigits),
+				}
+			}
+		}
+	}
+
+	if decimalPlacesTag != "" {
+		if decPlaces, err := strconv.Atoi(decimalPlacesTag); err == nil {
+			if len(decPart) > decPlaces {
+				return &Error{
+					ErrType: "DECIMAL_PLACES_ERR",
+					Path:    fieldName(f, tree),
+					Message: fmt.Sprintf("The field <%s> must have at most %d decimal places (got %d)", fieldName(f, tree), decPlaces, len(decPart)),
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/decimal_constraints_test.go
+++ b/decimal_constraints_test.go
@@ -1,0 +1,72 @@
+package godantic
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDecimalConstraints(t *testing.T) {
+	g := &Validate{}
+
+	t.Run("should allow valid float with max_digits and decimal_places", func(t *testing.T) {
+		type S struct {
+			Value *float64 `json:"value" max_digits:"6" decimal_places:"2"`
+		}
+		val := 1234.56
+		assert.NoError(t, g.InspectStruct(S{Value: &val}))
+	})
+
+	t.Run("should fail when exceeding max_digits", func(t *testing.T) {
+		type S struct {
+			Value *float64 `json:"value" max_digits:"5"`
+		}
+		val := 12345.6 // 6 digits total
+		err := g.InspectStruct(S{Value: &val})
+		assert.Error(t, err)
+		assert.Equal(t, "MAX_DIGITS_ERR", err.(*Error).ErrType)
+	})
+
+	t.Run("should fail when exceeding decimal_places", func(t *testing.T) {
+		type S struct {
+			Value *float64 `json:"value" decimal_places:"2"`
+		}
+		val := 123.456 // 3 decimal places
+		err := g.InspectStruct(S{Value: &val})
+		assert.Error(t, err)
+		assert.Equal(t, "DECIMAL_PLACES_ERR", err.(*Error).ErrType)
+	})
+
+	t.Run("should ignore trailing zeros in decimal places", func(t *testing.T) {
+		type S struct {
+			Value *float64 `json:"value" decimal_places:"2"`
+		}
+		val := 12.3000 // 1 decimal digit
+		assert.NoError(t, g.InspectStruct(S{Value: &val}))
+	})
+
+	t.Run("should ignore leading zero in int part", func(t *testing.T) {
+		type S struct {
+			Value *float64 `json:"value" max_digits:"3"`
+		}
+		val := 0.99 // only 2 digits (0 is ignored)
+		assert.NoError(t, g.InspectStruct(S{Value: &val}))
+	})
+
+	t.Run("should allow exact match with max_digits and decimal_places", func(t *testing.T) {
+		type S struct {
+			Value *float64 `json:"value" max_digits:"6" decimal_places:"2"`
+		}
+		val := 9999.99 // 6 digits, 2 decimals
+		assert.NoError(t, g.InspectStruct(S{Value: &val}))
+	})
+
+	t.Run("should fail with negative number if it exceeds digits", func(t *testing.T) {
+		type S struct {
+			Value *float64 `json:"value" max_digits:"3"`
+		}
+		val := -123.45 // 5 digits (ignore '-')
+		err := g.InspectStruct(S{Value: &val})
+		assert.Error(t, err)
+		assert.Equal(t, "MAX_DIGITS_ERR", err.(*Error).ErrType)
+	})
+}

--- a/range.go
+++ b/range.go
@@ -1,0 +1,180 @@
+package godantic
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"strconv"
+)
+
+func (g *Validate) checkMinMax(f reflect.StructField, v reflect.Value, tree string) error {
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+
+	minTag := f.Tag.Get("min")
+	maxTag := f.Tag.Get("max")
+
+	switch v.Kind() {
+	case reflect.String, reflect.Slice, reflect.Array:
+		length := v.Len()
+		if minTag != "" {
+			min, err := strconv.Atoi(minTag)
+			if err == nil && length < min {
+				return &Error{
+					ErrType: "MIN_LENGTH_ERR",
+					Path:    fieldName(f, tree),
+					Message: fmt.Sprintf("The field <%s> must have at least %d items, but has %d", fieldName(f, tree), min, length),
+				}
+			}
+		}
+		if maxTag != "" {
+			max, err := strconv.Atoi(maxTag)
+			if err == nil && length > max {
+				return &Error{
+					ErrType: "MAX_LENGTH_ERR",
+					Path:    fieldName(f, tree),
+					Message: fmt.Sprintf("The field <%s> must have at most %d items, but has %d", fieldName(f, tree), max, length),
+				}
+			}
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		val := v.Int()
+		if minTag != "" {
+			min, err := strconv.ParseInt(minTag, 10, 64)
+			if err == nil && val < min {
+				return &Error{
+					ErrType: "MIN_VALUE_ERR",
+					Path:    fieldName(f, tree),
+					Message: fmt.Sprintf("The field <%s> must be at least %d, but was %d", fieldName(f, tree), min, val),
+				}
+			}
+		}
+		if maxTag != "" {
+			max, err := strconv.ParseInt(maxTag, 10, 64)
+			if err == nil && val > max {
+				return &Error{
+					ErrType: "MAX_VALUE_ERR",
+					Path:    fieldName(f, tree),
+					Message: fmt.Sprintf("The field <%s> must be at most %d, but was %d", fieldName(f, tree), max, val),
+				}
+			}
+		}
+	case reflect.Float32, reflect.Float64:
+		val := v.Float()
+		if minTag != "" {
+			min, err := strconv.ParseFloat(minTag, 64)
+			if err == nil && val < min {
+				return &Error{
+					ErrType: "MIN_VALUE_ERR",
+					Path:    fieldName(f, tree),
+					Message: fmt.Sprintf("The field <%s> must be at least %.2f, but was %.2f", fieldName(f, tree), min, val),
+				}
+			}
+		}
+		if maxTag != "" {
+			max, err := strconv.ParseFloat(maxTag, 64)
+			if err == nil && val > max {
+				return &Error{
+					ErrType: "MAX_VALUE_ERR",
+					Path:    fieldName(f, tree),
+					Message: fmt.Sprintf("The field <%s> must be at most %.2f, but was %.2f", fieldName(f, tree), max, val),
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (g *Validate) checkNumericConstraints(f reflect.StructField, v reflect.Value, tree string) error {
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+
+	// Skip if not numeric
+	if !(v.Kind() >= reflect.Int && v.Kind() <= reflect.Float64) {
+		return nil
+	}
+
+	// Get tag values
+	gtTag := f.Tag.Get("gt")
+	ltTag := f.Tag.Get("lt")
+	geTag := f.Tag.Get("ge")
+	leTag := f.Tag.Get("le")
+	multipleOfTag := f.Tag.Get("multiple_of")
+	allowInfNaNTag := f.Tag.Get("allow_inf_nan")
+
+	var value float64
+	switch v.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		value = float64(v.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		value = float64(v.Uint())
+	case reflect.Float32, reflect.Float64:
+		value = v.Float()
+		if allowInfNaNTag != "true" && (math.IsNaN(value) || math.IsInf(value, 0)) {
+			return &Error{
+				ErrType: "INVALID_FLOAT_ERR",
+				Path:    fieldName(f, tree),
+				Message: "The field <" + fieldName(f, tree) + "> cannot be NaN or infinite",
+			}
+		}
+	default:
+		return nil
+	}
+
+	// Constraint checks
+	if gtTag != "" {
+		if threshold, err := strconv.ParseFloat(gtTag, 64); err == nil && !(value > threshold) {
+			return &Error{
+				ErrType: "GREATER_THAN_ERR",
+				Path:    fieldName(f, tree),
+				Message: fmt.Sprintf("The field <%s> must be greater than %v", fieldName(f, tree), threshold),
+			}
+		}
+	}
+	if geTag != "" {
+		if threshold, err := strconv.ParseFloat(geTag, 64); err == nil && !(value >= threshold) {
+			return &Error{
+				ErrType: "GREATER_EQUAL_ERR",
+				Path:    fieldName(f, tree),
+				Message: fmt.Sprintf("The field <%s> must be greater than or equal to %v", fieldName(f, tree), threshold),
+			}
+		}
+	}
+	if ltTag != "" {
+		if threshold, err := strconv.ParseFloat(ltTag, 64); err == nil && !(value < threshold) {
+			return &Error{
+				ErrType: "LESS_THAN_ERR",
+				Path:    fieldName(f, tree),
+				Message: fmt.Sprintf("The field <%s> must be less than %v", fieldName(f, tree), threshold),
+			}
+		}
+	}
+	if leTag != "" {
+		if threshold, err := strconv.ParseFloat(leTag, 64); err == nil && !(value <= threshold) {
+			return &Error{
+				ErrType: "LESS_EQUAL_ERR",
+				Path:    fieldName(f, tree),
+				Message: fmt.Sprintf("The field <%s> must be less than or equal to %v", fieldName(f, tree), threshold),
+			}
+		}
+	}
+	if multipleOfTag != "" {
+		if base, err := strconv.ParseFloat(multipleOfTag, 64); err == nil && base != 0 && math.Mod(value, base) != 0 {
+			return &Error{
+				ErrType: "NOT_MULTIPLE_ERR",
+				Path:    fieldName(f, tree),
+				Message: fmt.Sprintf("The field <%s> must be a multiple of %v", fieldName(f, tree), base),
+			}
+		}
+	}
+
+	return nil
+}

--- a/range_test.go
+++ b/range_test.go
@@ -1,0 +1,155 @@
+package godantic
+
+import (
+	"github.com/stretchr/testify/assert"
+	"math"
+	"testing"
+)
+
+func TestMinMaxValidation(t *testing.T) {
+	g := &Validate{}
+
+	t.Run("String length constraints", func(t *testing.T) {
+		type TestStruct struct {
+			Name *string `json:"name" min:"3" max:"5"`
+		}
+
+		short := "Hi"
+		long := "HelloWorld"
+		valid := "John"
+
+		assert.Error(t, g.InspectStruct(TestStruct{Name: &short}))
+		assert.Error(t, g.InspectStruct(TestStruct{Name: &long}))
+		assert.NoError(t, g.InspectStruct(TestStruct{Name: &valid}))
+	})
+
+	t.Run("Slice length constraints", func(t *testing.T) {
+		type TestStruct struct {
+			Items *[]string `json:"items" min:"2" max:"4"`
+		}
+
+		short := &[]string{"a"}
+		long := &[]string{"a", "b", "c", "d", "e"}
+		valid := &[]string{"a", "b"}
+
+		assert.Error(t, g.InspectStruct(TestStruct{Items: short}))
+		assert.Error(t, g.InspectStruct(TestStruct{Items: long}))
+		assert.NoError(t, g.InspectStruct(TestStruct{Items: valid}))
+	})
+
+	t.Run("Integer value constraints", func(t *testing.T) {
+		type TestStruct struct {
+			Age *int `json:"age" min:"18" max:"30"`
+		}
+
+		young := 17
+		old := 35
+		valid := 25
+
+		assert.Error(t, g.InspectStruct(TestStruct{Age: &young}))
+		assert.Error(t, g.InspectStruct(TestStruct{Age: &old}))
+		assert.NoError(t, g.InspectStruct(TestStruct{Age: &valid}))
+	})
+
+	t.Run("Float value constraints", func(t *testing.T) {
+		type TestStruct struct {
+			Score *float64 `json:"score" min:"1.5" max:"3.5"`
+		}
+
+		low := 1.4
+		high := 3.6
+		valid := 2.7
+
+		assert.Error(t, g.InspectStruct(TestStruct{Score: &low}))
+		assert.Error(t, g.InspectStruct(TestStruct{Score: &high}))
+		assert.NoError(t, g.InspectStruct(TestStruct{Score: &valid}))
+	})
+}
+
+func TestNumericConstraints(t *testing.T) {
+	g := &Validate{}
+
+	t.Run("should validate greater than (gt)", func(t *testing.T) {
+		type S struct {
+			Age *int `json:"age" gt:"18"`
+		}
+		age := 20
+		tooYoung := 18
+		assert.NoError(t, g.InspectStruct(S{Age: &age}))
+		assert.Error(t, g.InspectStruct(S{Age: &tooYoung}))
+	})
+
+	t.Run("should validate greater or equal (ge)", func(t *testing.T) {
+		type S struct {
+			Age *int `json:"age" ge:"18"`
+		}
+		age := 18
+		younger := 17
+		assert.NoError(t, g.InspectStruct(S{Age: &age}))
+		assert.Error(t, g.InspectStruct(S{Age: &younger}))
+	})
+
+	t.Run("should validate less than (lt)", func(t *testing.T) {
+		type S struct {
+			Age *int `json:"age" lt:"65"`
+		}
+		age := 60
+		tooOld := 70
+		assert.NoError(t, g.InspectStruct(S{Age: &age}))
+		assert.Error(t, g.InspectStruct(S{Age: &tooOld}))
+	})
+
+	t.Run("should validate less or equal (le)", func(t *testing.T) {
+		type S struct {
+			Age *int `json:"age" le:"30"`
+		}
+		age := 30
+		tooOld := 31
+		assert.NoError(t, g.InspectStruct(S{Age: &age}))
+		assert.Error(t, g.InspectStruct(S{Age: &tooOld}))
+	})
+
+	t.Run("should validate multiple_of", func(t *testing.T) {
+		type S struct {
+			Num *int `json:"num" multiple_of:"5"`
+		}
+		valid := 25
+		invalid := 23
+		assert.NoError(t, g.InspectStruct(S{Num: &valid}))
+		assert.Error(t, g.InspectStruct(S{Num: &invalid}))
+	})
+
+	t.Run("should validate float multiple_of", func(t *testing.T) {
+		type S struct {
+			Num *float64 `json:"num" multiple_of:"0.5"`
+		}
+		valid := 2.5
+		invalid := 2.3
+		assert.NoError(t, g.InspectStruct(S{Num: &valid}))
+		assert.Error(t, g.InspectStruct(S{Num: &invalid}))
+	})
+
+	t.Run("should reject NaN and Inf by default", func(t *testing.T) {
+		type S struct {
+			Value *float64 `json:"value"`
+		}
+		nan := math.NaN()
+		posInf := math.Inf(1)
+		negInf := math.Inf(-1)
+		assert.Error(t, g.InspectStruct(S{Value: &nan}))
+		assert.Error(t, g.InspectStruct(S{Value: &posInf}))
+		assert.Error(t, g.InspectStruct(S{Value: &negInf}))
+	})
+
+	t.Run("should allow NaN and Inf when allow_inf_nan is true", func(t *testing.T) {
+		type S struct {
+			Value *float64 `json:"value" allow_inf_nan:"true"`
+		}
+		nan := math.NaN()
+		posInf := math.Inf(1)
+		negInf := math.Inf(-1)
+		assert.NoError(t, g.InspectStruct(S{Value: &nan}))
+		assert.NoError(t, g.InspectStruct(S{Value: &posInf}))
+		assert.NoError(t, g.InspectStruct(S{Value: &negInf}))
+	})
+}

--- a/structcheck.go
+++ b/structcheck.go
@@ -289,6 +289,15 @@ func (g *Validate) checkField(val interface{}, v reflect.Value, t reflect.Type, 
 	if err := g.validateCondition(f, valField, tree, enumMap); err != nil {
 		return err
 	}
+	if err := g.checkMinMax(f, valField, tree); err != nil {
+		return err
+	}
+	if err := g.checkNumericConstraints(f, valField, tree); err != nil {
+		return err
+	}
+	if err := g.checkDecimalConstraints(f, valField, tree); err != nil {
+		return err
+	}
 
 	if err := g.regexPattern(f, valField, tree); err != nil {
 		return err


### PR DESCRIPTION
### 🚀 Add Advanced Validation Rules: `min`, `max`, `gt`, `lt`, `ge`, `le`, `multiple_of`, `max_digits`, `decimal_places`, `allow_inf_nan`

#### ✨ What's New
This PR introduces support for a comprehensive set of numeric and decimal validation tags in `godantic`, allowing for more expressive and precise data constraints.

#### ✅ Added Features
- `min` / `max`: Support for string length, slice length, and numeric value ranges.
- `gt` / `ge` / `lt` / `le`: Numeric bounds (exclusive/inclusive).
- `multiple_of`: Ensures a value is a multiple of a given number.
- `max_digits`: Enforces total number of digits (before + after decimal).
- `decimal_places`: Restricts number of digits after the decimal point.
- `allow_inf_nan`: Allows validation of `+Inf`, `-Inf`, and `NaN` for float values.

#### 🧪 Coverage
- Unit tests added for all new constraints (`TestNumericConstraints`, `TestDecimalConstraints`)
- Validation behavior tested for both valid and invalid inputs across numeric types

#### 📚 Docs
- README updated with:
  - Usage examples
  - Validation matrix summarizing all supported tags

#### 💡 Notes
- All validations are applied only if the field is non-nil (unless marked as `required`)
- Compatible with pointer types (e.g. `*int`, `*float64`, `*string`)
- `default` tag support is deferred for now
